### PR TITLE
add link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CurrencyLayer
 PHP class for implementation of Currency layer API
 
+ [![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/Currencylayer/functions?utm_source=CurrencyLayerGithub&utm_medium=button&utm_content=Vender_Github)
+
 API Provider : https://currencylayer.com/
 


### PR DESCRIPTION
Hey there. I added a link in your README to a tool I built where you can test out the API calls in your browser before using your SDK to connect to the API. I've built something similar for other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback.